### PR TITLE
Feature/zplug as gitmodule

### DIFF
--- a/.dot/install/setup-shell.sh
+++ b/.dot/install/setup-shell.sh
@@ -1,8 +1,5 @@
 #!/bin/bash
 
-# ZPLUG
-curl -sL --proto-redir -all,https https://raw.githubusercontent.com/zplug/installer/master/installer.zsh | zsh
-
 # SDKMan
 curl -s "https://get.sdkman.io" | bash
 

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule ".tmux/plugins/tpm"]
 	path = .tmux/plugins/tpm
 	url = https://github.com/tmux-plugins/tpm.git
+[submodule ".zplug"]
+	path = ./zplug
+	url = https://github.com/zplug/zplug.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -2,5 +2,5 @@
 	path = .tmux/plugins/tpm
 	url = https://github.com/tmux-plugins/tpm.git
 [submodule ".zplug"]
-	path = ./zplug
+	path = .zplug
 	url = https://github.com/zplug/zplug.git

--- a/.zshrc
+++ b/.zshrc
@@ -6,13 +6,15 @@ source ~/.zplug/init.zsh
 
 # Zplug plugins
 zplug "zplug/zplug"
+zplug 'plugins/git', from:oh-my-zsh
+zplug 'plugins/virtualenv', from:oh-my-zsh
+zplug 'plugins/docker', from:oh-my-zsh
+zplug 'plugins/docker-compose', from:oh-my-zsh
 zplug "zsh-users/zsh-completions"
 zplug "tarruda/zsh-autosuggestions",            defer:1
 zplug "zsh-users/zsh-syntax-highlighting",      defer:2
 zplug "zsh-users/zsh-history-substring-search", defer:3
-zplug 'plugins/git', from:oh-my-zsh
-zplug 'plugins/virtualenv', from:oh-my-zsh
-zplug 'plugins/docker-compose', from:oh-my-zsh
+zplug "matthieusb/zsh-sdkman", use:zsh-sdkman.plugin
 zplug "bhilburn/powerlevel9k", use:powerlevel9k.zsh-theme
 zplug "b4b4r07/git-open", as:command, at:patch-1
 zplug "junegunn/fzf", as:command, hook-build:"./install --all", use:"bin/{fzf-tmux,fzf}"
@@ -31,7 +33,6 @@ export ZSH=$HOME/.zplug/repos/robbyrussell/oh-my-zsh
 # ZSH_THEME=agnoster
 
 fpath=(~/.zsh/completion $fpath)
-autoload -Uz compinit && compinit -i
 
 source $ZSH/oh-my-zsh.sh
 
@@ -72,3 +73,5 @@ source $HOME/.dot/aliases/aliases
 #THIS MUST BE AT THE END OF THE FILE FOR SDKMAN TO WORK!!!
 export SDKMAN_DIR="$HOME/.sdkman"
 [[ -s "$HOME/.sdkman/bin/sdkman-init.sh" ]] && source "$HOME/.sdkman/bin/sdkman-init.sh"
+
+autoload -Uz compinit ; compinit


### PR DESCRIPTION
This PR adds zplug as git submodule, therefore no manual installation is needed anymore.